### PR TITLE
Fix Inf Recursion Mount and LOS/Havoc Flash Fail

### DIFF
--- a/recovery/root/etc/recovery.fstab
+++ b/recovery/root/etc/recovery.fstab
@@ -6,7 +6,8 @@
 # Currently we dont have e2fsck compiled. So fs check would failed.
 
 #<src>					                 <mnt_point>		    <type>	<mnt_flags and options>				<fs_mgr_flags>
-/dev/block/bootdevice/by-name/system	 /		                ext4	ro,barrier=1,discard				wait,slotselect
+/dev/block/bootdevice/by-name/system    /system_root/system     ext4    ro,barrier=1,discard    wait,slotselect
+/system_root/system                     /system                 none    defaults,bind wait
 /dev/block/bootdevice/by-name/userdata   /data                  f2fs    rw,discard,nosuid,nodev,noatime,nodiratime,nobarrier,inline_xattr,inline_data,reserve_root=32768,resgid=1065    wait,check,formattable,fileencryption=ice,quota,reservedsize=128M
 /devices/soc/7864900.sdhci/mmc_host*	 auto		            auto	nosuid,nodev					    wait,voldmanaged=sdcard1:auto,encryptable=userdata
 /dev/block/zram0				         none		            swap	defaults							zramsize=1073741824

--- a/recovery/root/init.recovery.qcom.rc
+++ b/recovery/root/init.recovery.qcom.rc
@@ -19,6 +19,7 @@ on property:modules.loaded=1
 
 on boot
     setprop sys.usb.config adb
+    mkdir /system_root/system
 
 service prepdecrypt /sbin/prepdecrypt.sh
     oneshot


### PR DESCRIPTION
/system/etc is symlinked to /system/etc when you mount /system because it does /system/system/.

Lets fix that. This fixes a TON of errors.